### PR TITLE
Add linter CI and refactoring

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
-            components: clippy
-            override: true
+          toolchain: stable
+          components: clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,6 +23,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: rustfmt
       - run: cargo fmt -- --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  clippy_check:
+    name: Run Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+  format_check:
+    name: Run Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - run: cargo fmt -- --check

--- a/examples/binary_classification/src/main.rs
+++ b/examples/binary_classification/src/main.rs
@@ -48,9 +48,9 @@ fn main() -> std::io::Result<()> {
 
     let mut tp = 0;
     for (label, pred) in zip(&test_labels, &result[0]) {
-        if label == &(1 as f32) && pred > &(0.5 as f64) {
+        if *label == 1_f32 && *pred > 0.5_f64 {
             tp = tp + 1;
-        } else if label == &(0 as f32) && pred <= &(0.5 as f64) {
+        } else if *label == 0_f32 && *pred <= 0.5_f64 {
             tp = tp + 1;
         }
         println!("{}, {}", label, pred)

--- a/examples/binary_classification/src/main.rs
+++ b/examples/binary_classification/src/main.rs
@@ -1,35 +1,41 @@
-extern crate lightgbm;
 extern crate csv;
-extern crate serde_json;
 extern crate itertools;
-
+extern crate lightgbm;
+extern crate serde_json;
 
 use itertools::zip;
-use lightgbm::{Dataset, Booster};
+use lightgbm::{Booster, Dataset};
 use serde_json::json;
 
-
 fn load_file(file_path: &str) -> (Vec<Vec<f64>>, Vec<f32>) {
-    let rdr = csv::ReaderBuilder::new().has_headers(false).delimiter(b'\t').from_path(file_path);
+    let rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .delimiter(b'\t')
+        .from_path(file_path);
     let mut labels: Vec<f32> = Vec::new();
     let mut features: Vec<Vec<f64>> = Vec::new();
     for result in rdr.unwrap().records() {
         let record = result.unwrap();
         let label = record[0].parse::<f32>().unwrap();
-        let feature: Vec<f64> = record.iter().map(|x| x.parse::<f64>().unwrap()).collect::<Vec<f64>>()[1..].to_vec();
+        let feature: Vec<f64> = record
+            .iter()
+            .map(|x| x.parse::<f64>().unwrap())
+            .collect::<Vec<f64>>()[1..]
+            .to_vec();
         labels.push(label);
         features.push(feature);
     }
     (features, labels)
 }
 
-
 fn main() -> std::io::Result<()> {
-    let (train_features, train_labels) = load_file("../../lightgbm-sys/lightgbm/examples/binary_classification/binary.train");
-    let (test_features, test_labels) = load_file("../../lightgbm-sys/lightgbm/examples/binary_classification/binary.test");
+    let (train_features, train_labels) =
+        load_file("../../lightgbm-sys/lightgbm/examples/binary_classification/binary.train");
+    let (test_features, test_labels) =
+        load_file("../../lightgbm-sys/lightgbm/examples/binary_classification/binary.test");
     let train_dataset = Dataset::from_mat(train_features, train_labels).unwrap();
 
-    let params = json!{
+    let params = json! {
         {
             "num_iterations": 100,
             "objective": "binary",
@@ -40,9 +46,8 @@ fn main() -> std::io::Result<()> {
     let booster = Booster::train(train_dataset, &params).unwrap();
     let result = booster.predict(test_features).unwrap();
 
-
     let mut tp = 0;
-    for (label, pred) in zip(&test_labels, &result[0]){
+    for (label, pred) in zip(&test_labels, &result[0]) {
         if label == &(1 as f32) && pred > &(0.5 as f64) {
             tp = tp + 1;
         } else if label == &(0 as f32) && pred <= &(0.5 as f64) {

--- a/examples/binary_classification/src/main.rs
+++ b/examples/binary_classification/src/main.rs
@@ -48,10 +48,8 @@ fn main() -> std::io::Result<()> {
 
     let mut tp = 0;
     for (label, pred) in zip(&test_labels, &result[0]) {
-        if *label == 1_f32 && *pred > 0.5_f64 {
-            tp = tp + 1;
-        } else if *label == 0_f32 && *pred <= 0.5_f64 {
-            tp = tp + 1;
+        if (*label == 1_f32 && *pred > 0.5_f64) || (*label == 0_f32 && *pred <= 0.5_f64) {
+            tp += 1;
         }
         println!("{}, {}", label, pred)
     }

--- a/examples/multiclass_classification/src/main.rs
+++ b/examples/multiclass_classification/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> std::io::Result<()> {
     for (label, pred) in zip(&test_labels, &result) {
         let argmax_pred = argmax(&pred);
         if *label == argmax_pred as f32 {
-            tp = tp + 1;
+            tp += 1;
         }
         println!("{}, {}, {:?}", label, argmax_pred, &pred);
     }

--- a/examples/multiclass_classification/src/main.rs
+++ b/examples/multiclass_classification/src/main.rs
@@ -1,22 +1,27 @@
-extern crate lightgbm;
 extern crate csv;
-extern crate serde_json;
 extern crate itertools;
-
+extern crate lightgbm;
+extern crate serde_json;
 
 use itertools::zip;
-use lightgbm::{Dataset, Booster};
+use lightgbm::{Booster, Dataset};
 use serde_json::json;
 
-
 fn load_file(file_path: &str) -> (Vec<Vec<f64>>, Vec<f32>) {
-    let rdr = csv::ReaderBuilder::new().has_headers(false).delimiter(b'\t').from_path(file_path);
+    let rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .delimiter(b'\t')
+        .from_path(file_path);
     let mut labels: Vec<f32> = Vec::new();
     let mut features: Vec<Vec<f64>> = Vec::new();
     for result in rdr.unwrap().records() {
         let record = result.unwrap();
         let label = record[0].parse::<f32>().unwrap();
-        let feature: Vec<f64> = record.iter().map(|x| x.parse::<f64>().unwrap()).collect::<Vec<f64>>()[1..].to_vec();
+        let feature: Vec<f64> = record
+            .iter()
+            .map(|x| x.parse::<f64>().unwrap())
+            .collect::<Vec<f64>>()[1..]
+            .to_vec();
         labels.push(label);
         features.push(feature);
     }
@@ -42,11 +47,14 @@ fn argmax<T: PartialOrd>(xs: &[T]) -> usize {
 }
 
 fn main() -> std::io::Result<()> {
-    let (train_features, train_labels) = load_file("../../lightgbm-sys/lightgbm/examples/multiclass_classification/multiclass.train");
-    let (test_features, test_labels) = load_file("../../lightgbm-sys/lightgbm/examples/multiclass_classification/multiclass.test");
+    let (train_features, train_labels) = load_file(
+        "../../lightgbm-sys/lightgbm/examples/multiclass_classification/multiclass.train",
+    );
+    let (test_features, test_labels) =
+        load_file("../../lightgbm-sys/lightgbm/examples/multiclass_classification/multiclass.test");
     let train_dataset = Dataset::from_mat(train_features, train_labels).unwrap();
 
-    let params = json!{
+    let params = json! {
         {
             "num_iterations": 100,
             "objective": "multiclass",
@@ -58,9 +66,8 @@ fn main() -> std::io::Result<()> {
     let booster = Booster::train(train_dataset, &params).unwrap();
     let result = booster.predict(test_features).unwrap();
 
-
     let mut tp = 0;
-    for (label, pred) in zip(&test_labels, &result){
+    for (label, pred) in zip(&test_labels, &result) {
         let argmax_pred = argmax(&pred);
         if *label == argmax_pred as f32 {
             tp = tp + 1;

--- a/examples/regression/src/main.rs
+++ b/examples/regression/src/main.rs
@@ -48,9 +48,9 @@ fn main() -> std::io::Result<()> {
 
     let mut tp = 0;
     for (label, pred) in zip(&test_labels, &result[0]) {
-        if label == &(1 as f32) && pred > &(0.5 as f64) {
+        if *label == 1_f32 && *pred > 0.5_f64 {
             tp = tp + 1;
-        } else if label == &(0 as f32) && pred <= &(0.5 as f64) {
+        } else if *label == 0_f32 && *pred <= 0.5_f64 {
             tp = tp + 1;
         }
         println!("{}, {}", label, pred)

--- a/examples/regression/src/main.rs
+++ b/examples/regression/src/main.rs
@@ -1,35 +1,41 @@
-extern crate lightgbm;
 extern crate csv;
-extern crate serde_json;
 extern crate itertools;
-
+extern crate lightgbm;
+extern crate serde_json;
 
 use itertools::zip;
-use lightgbm::{Dataset, Booster};
+use lightgbm::{Booster, Dataset};
 use serde_json::json;
 
-
 fn load_file(file_path: &str) -> (Vec<Vec<f64>>, Vec<f32>) {
-    let rdr = csv::ReaderBuilder::new().has_headers(false).delimiter(b'\t').from_path(file_path);
+    let rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .delimiter(b'\t')
+        .from_path(file_path);
     let mut labels: Vec<f32> = Vec::new();
     let mut features: Vec<Vec<f64>> = Vec::new();
     for result in rdr.unwrap().records() {
         let record = result.unwrap();
         let label = record[0].parse::<f32>().unwrap();
-        let feature: Vec<f64> = record.iter().map(|x| x.parse::<f64>().unwrap()).collect::<Vec<f64>>()[1..].to_vec();
+        let feature: Vec<f64> = record
+            .iter()
+            .map(|x| x.parse::<f64>().unwrap())
+            .collect::<Vec<f64>>()[1..]
+            .to_vec();
         labels.push(label);
         features.push(feature);
     }
     (features, labels)
 }
 
-
 fn main() -> std::io::Result<()> {
-    let (train_features, train_labels) = load_file("../../lightgbm-sys/lightgbm/examples/regression/regression.train");
-    let (test_features, test_labels) = load_file("../../lightgbm-sys/lightgbm/examples/regression/regression.test");
+    let (train_features, train_labels) =
+        load_file("../../lightgbm-sys/lightgbm/examples/regression/regression.train");
+    let (test_features, test_labels) =
+        load_file("../../lightgbm-sys/lightgbm/examples/regression/regression.test");
     let train_dataset = Dataset::from_mat(train_features, train_labels).unwrap();
 
-    let params = json!{
+    let params = json! {
         {
             "num_iterations": 100,
             "objective": "regression",
@@ -40,9 +46,8 @@ fn main() -> std::io::Result<()> {
     let booster = Booster::train(train_dataset, &params).unwrap();
     let result = booster.predict(test_features).unwrap();
 
-
     let mut tp = 0;
-    for (label, pred) in zip(&test_labels, &result[0]){
+    for (label, pred) in zip(&test_labels, &result[0]) {
         if label == &(1 as f32) && pred > &(0.5 as f64) {
             tp = tp + 1;
         } else if label == &(0 as f32) && pred <= &(0.5 as f64) {

--- a/examples/regression/src/main.rs
+++ b/examples/regression/src/main.rs
@@ -48,10 +48,8 @@ fn main() -> std::io::Result<()> {
 
     let mut tp = 0;
     for (label, pred) in zip(&test_labels, &result[0]) {
-        if *label == 1_f32 && *pred > 0.5_f64 {
-            tp = tp + 1;
-        } else if *label == 0_f32 && *pred <= 0.5_f64 {
-            tp = tp + 1;
+        if (*label == 1_f32 && *pred > 0.5_f64) || (*label == 0_f32 && *pred <= 0.5_f64) {
+            tp += 1;
         }
         println!("{}, {}", label, pred)
     }

--- a/lightgbm-sys/src/lib.rs
+++ b/lightgbm-sys/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(clippy::redundant_static_lifetimes)]
+#![allow(clippy::missing_safety_doc)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -221,11 +221,11 @@ mod tests {
         let bst = Booster::train(dataset, &params).unwrap();
         bst.save_file("./test/test_save_file.output".to_string());
         assert!(Path::new("./test/test_save_file.output").exists());
-        fs::remove_file("./test/test_save_file.output");
+        let _ = fs::remove_file("./test/test_save_file.output");
     }
 
     #[test]
     fn from_file() {
-        let bst = Booster::from_file("./test/test_from_file.input".to_string());
+        let _ = Booster::from_file("./test/test_from_file.input".to_string());
     }
 }

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -14,8 +14,8 @@ pub struct Booster {
 }
 
 impl Booster {
-    fn new(handle: lightgbm_sys::BoosterHandle) -> LGBMResult<Self> {
-        Ok(Booster { handle })
+    fn new(handle: lightgbm_sys::BoosterHandle) -> Self {
+        Booster { handle }
     }
 
     /// Init from model file.
@@ -27,9 +27,9 @@ impl Booster {
             filename_str.as_ptr() as *const c_char,
             &mut out_num_iterations,
             &mut handle
-        ))
-        .unwrap();
-        Ok(Booster::new(handle)?)
+        ))?;
+
+        Ok(Booster::new(handle))
     }
 
     /// Create a new Booster model with given Dataset and parameters.
@@ -89,7 +89,7 @@ impl Booster {
                 &mut is_finished
             ))?;
         }
-        Ok(Booster::new(handle)?)
+        Ok(Booster::new(handle))
     }
 
     /// Predict results for given data.

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -58,12 +58,11 @@ impl Booster {
     /// ```
     pub fn train(dataset: Dataset, parameter: &Value) -> LGBMResult<Self> {
         // get num_iterations
-        let num_iterations: i64;
-        if parameter["num_iterations"].is_null() {
-            num_iterations = 100;
+        let num_iterations: i64 = if parameter["num_iterations"].is_null() {
+            100
         } else {
-            num_iterations = parameter["num_iterations"].as_i64().unwrap();
-        }
+            parameter["num_iterations"].as_i64().unwrap()
+        };
 
         // exchange params {"x": "y", "z": 1} => "x=y z=1"
         let params_string = parameter
@@ -137,15 +136,14 @@ impl Booster {
         ))?;
 
         // reshape for multiclass [1,2,3,4,5,6] -> [[1,2,3], [4,5,6]]  # 3 class
-        let reshaped_output;
-        if num_class > 1 {
-            reshaped_output = out_result
+        let reshaped_output = if num_class > 1 {
+            out_result
                 .chunks(num_class as usize)
                 .map(|x| x.to_vec())
-                .collect();
+                .collect()
         } else {
-            reshaped_output = vec![out_result];
-        }
+            vec![out_result]
+        };
         Ok(reshaped_output)
     }
 
@@ -198,11 +196,7 @@ mod tests {
         let result = bst.predict(feature).unwrap();
         let mut normalized_result = Vec::new();
         for r in &result[0] {
-            if r > &0.5 {
-                normalized_result.push(1);
-            } else {
-                normalized_result.push(0);
-            }
+            normalized_result.push(if r > &0.5 { 1 } else { 0 });
         }
         assert_eq!(normalized_result, vec![0, 0, 1]);
     }

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -1,4 +1,4 @@
-use libc::{c_char, c_double, c_long, c_longlong, c_void};
+use libc::{c_char, c_double, c_longlong, c_void};
 use std;
 use std::ffi::CString;
 

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -127,10 +127,10 @@ impl Booster {
             lightgbm_sys::C_API_DTYPE_FLOAT64 as i32,
             data_length as i32,
             feature_length as i32,
-            1 as i32,
-            0 as i32,
-            0 as i32,
-            -1 as i32,
+            1_i32,
+            0_i32,
+            0_i32,
+            -1_i32,
             params.as_ptr() as *const c_char,
             &mut out_length,
             out_result.as_ptr() as *mut c_double
@@ -154,9 +154,9 @@ impl Booster {
         let filename_str = CString::new(filename).unwrap();
         lgbm_call!(lightgbm_sys::LGBM_BoosterSaveModel(
             self.handle,
-            0 as i32,
-            -1 as i32,
-            0 as i32,
+            0_i32,
+            -1_i32,
+            0_i32,
             filename_str.as_ptr() as *const c_char
         ))
         .unwrap();

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -38,8 +38,8 @@ pub struct Dataset {
 
 #[link(name = "c")]
 impl Dataset {
-    fn new(handle: lightgbm_sys::DatasetHandle) -> LGBMResult<Self> {
-        Ok(Dataset { handle })
+    fn new(handle: lightgbm_sys::DatasetHandle) -> Self {
+        Dataset { handle }
     }
 
     /// Create a new `Dataset` from dense array in row-major order.
@@ -84,7 +84,7 @@ impl Dataset {
             lightgbm_sys::C_API_DTYPE_FLOAT32 as i32
         ))?;
 
-        Ok(Dataset::new(handle)?)
+        Ok(Dataset::new(handle))
     }
 
     /// Create a new `Dataset` from file.
@@ -118,7 +118,7 @@ impl Dataset {
             &mut handle
         ))?;
 
-        Ok(Dataset::new(handle)?)
+        Ok(Dataset::new(handle))
     }
 }
 

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -70,7 +70,7 @@ impl Dataset {
             lightgbm_sys::C_API_DTYPE_FLOAT64 as i32,
             data_length as i32,
             feature_length as i32,
-            1 as i32,
+            1_i32,
             params.as_ptr() as *const c_char,
             reference,
             &mut handle

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,9 +41,7 @@ impl LGBMError {
     fn from_lightgbm() -> Self {
         let c_str = unsafe { CStr::from_ptr(lightgbm_sys::LGBM_GetLastError()) };
         let str_slice = c_str.to_str().unwrap();
-        LGBMError {
-            desc: str_slice.to_owned(),
-        }
+        Self::new(str_slice)
     }
 }
 
@@ -65,11 +63,6 @@ mod tests {
         assert_eq!(result, Ok(()));
 
         let result = LGBMError::check_return_value(-1);
-        assert_eq!(
-            result,
-            Err(LGBMError {
-                desc: "Everything is fine".to_owned()
-            })
-        );
+        assert_eq!(result, Err(LGBMError::new("Everything is fine")));
     }
 }


### PR DESCRIPTION
- Add CI to run clippy and format checking.
- Fixes all clippy warning.
  - Removes unused imports.
  - Removes primitive casting.
  - Removes unnecessary wrapping results and `?`.
- Format examples.
- Shorten some `if` expressions.
- Uses `new` to construct LGBMError.