### PR TITLE
Avoid redundant prefixes

### DIFF
--- a/src/booster.rs
+++ b/src/booster.rs
@@ -148,7 +148,7 @@ impl Booster {
     }
 
     /// Save model to file.
-    pub fn save_file(&self, filename: String) {
+    pub fn save_file(&self, filename: String) -> Result<()> {
         let filename_str = CString::new(filename).unwrap();
         lgbm_call!(lightgbm_sys::LGBM_BoosterSaveModel(
             self.handle,
@@ -156,8 +156,8 @@ impl Booster {
             -1_i32,
             0_i32,
             filename_str.as_ptr() as *const c_char
-        ))
-        .unwrap();
+        ))?;
+        Ok(())
     }
 }
 
@@ -213,7 +213,10 @@ mod tests {
             }
         };
         let bst = Booster::train(dataset, &params).unwrap();
-        bst.save_file("./test/test_save_file.output".to_string());
+        assert_eq!(
+            bst.save_file("./test/test_save_file.output".to_string()),
+            Ok(())
+        );
         assert!(Path::new("./test/test_save_file.output").exists());
         let _ = fs::remove_file("./test/test_save_file.output");
     }

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use lightgbm_sys;
 
-use super::{Dataset, LGBMError, LGBMResult};
+use super::{Dataset, Error, Result};
 
 /// Core model in LightGBM, containing functions for training, evaluating and predicting.
 pub struct Booster {
@@ -19,7 +19,7 @@ impl Booster {
     }
 
     /// Init from model file.
-    pub fn from_file(filename: String) -> LGBMResult<Self> {
+    pub fn from_file(filename: String) -> Result<Self> {
         let filename_str = CString::new(filename).unwrap();
         let mut out_num_iterations = 0;
         let mut handle = std::ptr::null_mut();
@@ -56,7 +56,7 @@ impl Booster {
     /// };
     /// let bst = Booster::train(dataset, &params).unwrap();
     /// ```
-    pub fn train(dataset: Dataset, parameter: &Value) -> LGBMResult<Self> {
+    pub fn train(dataset: Dataset, parameter: &Value) -> Result<Self> {
         // get num_iterations
         let num_iterations: i64 = if parameter["num_iterations"].is_null() {
             100
@@ -104,7 +104,7 @@ impl Booster {
     /// ```
     /// let output = vec![vec![1.0, 0.109, 0.433]];
     /// ```
-    pub fn predict(&self, data: Vec<Vec<f64>>) -> LGBMResult<Vec<Vec<f64>>> {
+    pub fn predict(&self, data: Vec<Vec<f64>>) -> Result<Vec<Vec<f64>>> {
         let data_length = data.len();
         let feature_length = data[0].len();
         let params = CString::new("").unwrap();
@@ -174,7 +174,7 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
-    fn read_train_file() -> LGBMResult<Dataset> {
+    fn read_train_file() -> Result<Dataset> {
         Dataset::from_file(
             "lightgbm-sys/lightgbm/examples/binary_classification/binary.train".to_string(),
         )

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -3,7 +3,7 @@ use lightgbm_sys;
 use std;
 use std::ffi::CString;
 
-use super::{LGBMError, LGBMResult};
+use super::{Error, Result};
 
 /// Dataset used throughout LightGBM for training.
 ///
@@ -56,7 +56,7 @@ impl Dataset {
     /// let label = vec![0.0, 0.0, 0.0, 1.0, 1.0];
     /// let dataset = Dataset::from_mat(data, label).unwrap();
     /// ```
-    pub fn from_mat(data: Vec<Vec<f64>>, label: Vec<f32>) -> LGBMResult<Self> {
+    pub fn from_mat(data: Vec<Vec<f64>>, label: Vec<f32>) -> Result<Self> {
         let data_length = data.len();
         let feature_length = data[0].len();
         let params = CString::new("").unwrap();
@@ -106,7 +106,7 @@ impl Dataset {
     ///
     /// let dataset = Dataset::from_file("lightgbm-sys/lightgbm/examples/binary_classification/binary.train".to_string());
     /// ```
-    pub fn from_file(file_path: String) -> LGBMResult<Self> {
+    pub fn from_file(file_path: String) -> Result<Self> {
         let file_path_str = CString::new(file_path).unwrap();
         let params = CString::new("").unwrap();
         let mut handle = std::ptr::null_mut();
@@ -131,7 +131,7 @@ impl Drop for Dataset {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn read_train_file() -> LGBMResult<Dataset> {
+    fn read_train_file() -> Result<Dataset> {
         Dataset::from_file(
             "lightgbm-sys/lightgbm/examples/binary_classification/binary.train".to_string(),
         )

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,24 +1,23 @@
 //! Functionality related to errors and error handling.
 
-use std;
-use std::error::Error;
+use std::error;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
 use lightgbm_sys;
 
 /// Convenience return type for most operations which can return an `LightGBM`.
-pub type LGBMResult<T> = std::result::Result<T, LGBMError>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Wrap errors returned by the LightGBM library.
 #[derive(Debug, Eq, PartialEq)]
-pub struct LGBMError {
+pub struct Error {
     desc: String,
 }
 
-impl LGBMError {
+impl Error {
     pub(crate) fn new<S: Into<String>>(desc: S) -> Self {
-        LGBMError { desc: desc.into() }
+        Error { desc: desc.into() }
     }
 
     /// Check the return value from an LightGBM FFI call, and return the last error message on error.
@@ -26,10 +25,10 @@ impl LGBMError {
     /// Return values of 0 are treated as success, returns values of -1 are treated as errors.
     ///
     /// Meaning of any other return values are undefined, and will cause a panic.
-    pub(crate) fn check_return_value(ret_val: i32) -> LGBMResult<()> {
+    pub(crate) fn check_return_value(ret_val: i32) -> Result<()> {
         match ret_val {
             0 => Ok(()),
-            -1 => Err(LGBMError::from_lightgbm()),
+            -1 => Err(Error::from_lightgbm()),
             _ => panic!(format!(
                 "unexpected return value '{}', expected 0 or -1",
                 ret_val
@@ -45,9 +44,9 @@ impl LGBMError {
     }
 }
 
-impl Error for LGBMError {}
+impl error::Error for Error {}
 
-impl Display for LGBMError {
+impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "LightGBM error: {}", &self.desc)
     }
@@ -59,10 +58,10 @@ mod tests {
 
     #[test]
     fn return_value_handling() {
-        let result = LGBMError::check_return_value(0);
+        let result = Error::check_return_value(0);
         assert_eq!(result, Ok(()));
 
-        let result = LGBMError::check_return_value(-1);
-        assert_eq!(result, Err(LGBMError::new("Everything is fine")));
+        let result = Error::check_return_value(-1);
+        assert_eq!(result, Err(Error::new("Everything is fine")));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@ extern crate serde_json;
 #[macro_use]
 macro_rules! lgbm_call {
     ($x:expr) => {
-        LGBMError::check_return_value(unsafe { $x })
+        Error::check_return_value(unsafe { $x })
     };
 }
 
 mod error;
-pub use error::{LGBMError, LGBMResult};
+pub use error::{Error, Result};
 
 mod dataset;
 pub use dataset::Dataset;


### PR DESCRIPTION
* Renames `LGBMError` to `Error` and `LGBMResult` to `Result`.
  * See details https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#avoid-redundant-prefixes-[rfc-356]
* Changes booster::save_file return value to Result for avoiding panic.