### PR TITLE
take &str arguments instead of String

### DIFF
--- a/src/booster.rs
+++ b/src/booster.rs
@@ -19,7 +19,7 @@ impl Booster {
     }
 
     /// Init from model file.
-    pub fn from_file(filename: String) -> Result<Self> {
+    pub fn from_file(filename: &str) -> Result<Self> {
         let filename_str = CString::new(filename).unwrap();
         let mut out_num_iterations = 0;
         let mut handle = std::ptr::null_mut();
@@ -148,7 +148,7 @@ impl Booster {
     }
 
     /// Save model to file.
-    pub fn save_file(&self, filename: String) -> Result<()> {
+    pub fn save_file(&self, filename: &str) -> Result<()> {
         let filename_str = CString::new(filename).unwrap();
         lgbm_call!(lightgbm_sys::LGBM_BoosterSaveModel(
             self.handle,
@@ -175,9 +175,7 @@ mod tests {
     use std::path::Path;
 
     fn read_train_file() -> Result<Dataset> {
-        Dataset::from_file(
-            "lightgbm-sys/lightgbm/examples/binary_classification/binary.train".to_string(),
-        )
+        Dataset::from_file(&"lightgbm-sys/lightgbm/examples/binary_classification/binary.train")
     }
 
     #[test]
@@ -213,16 +211,13 @@ mod tests {
             }
         };
         let bst = Booster::train(dataset, &params).unwrap();
-        assert_eq!(
-            bst.save_file("./test/test_save_file.output".to_string()),
-            Ok(())
-        );
+        assert_eq!(bst.save_file(&"./test/test_save_file.output"), Ok(()));
         assert!(Path::new("./test/test_save_file.output").exists());
         let _ = fs::remove_file("./test/test_save_file.output");
     }
 
     #[test]
     fn from_file() {
-        let _ = Booster::from_file("./test/test_from_file.input".to_string());
+        let _ = Booster::from_file(&"./test/test_from_file.input");
     }
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -28,9 +28,7 @@ use super::{Error, Result};
 /// ```
 /// use lightgbm::Dataset;
 ///
-/// let dataset = Dataset::from_file(
-///     "lightgbm-sys/lightgbm/examples/binary_classification/binary.train"
-///     .to_string()).unwrap();
+/// let dataset = Dataset::from_file(&"lightgbm-sys/lightgbm/examples/binary_classification/binary.train").unwrap();
 /// ```
 pub struct Dataset {
     pub(super) handle: lightgbm_sys::DatasetHandle,
@@ -104,9 +102,9 @@ impl Dataset {
     /// ```
     /// use lightgbm::Dataset;
     ///
-    /// let dataset = Dataset::from_file("lightgbm-sys/lightgbm/examples/binary_classification/binary.train".to_string());
+    /// let dataset = Dataset::from_file(&"lightgbm-sys/lightgbm/examples/binary_classification/binary.train");
     /// ```
-    pub fn from_file(file_path: String) -> Result<Self> {
+    pub fn from_file(file_path: &str) -> Result<Self> {
         let file_path_str = CString::new(file_path).unwrap();
         let params = CString::new("").unwrap();
         let mut handle = std::ptr::null_mut();
@@ -132,9 +130,7 @@ impl Drop for Dataset {
 mod tests {
     use super::*;
     fn read_train_file() -> Result<Dataset> {
-        Dataset::from_file(
-            "lightgbm-sys/lightgbm/examples/binary_classification/binary.train".to_string(),
-        )
+        Dataset::from_file(&"lightgbm-sys/lightgbm/examples/binary_classification/binary.train")
     }
 
     #[test]


### PR DESCRIPTION
It is better to take &str arguments for just reading it.
Using String requires extra memory allocation in some cases.