### PR TITLE
configure C++11 even more explicitly as suggested in #40

### DIFF
--- a/lightgbm-sys/build.rs
+++ b/lightgbm-sys/build.rs
@@ -39,6 +39,7 @@ fn main() {
     let dst = Config::new(&lgbm_root)
         .profile("Release")
         .uses_cxx11()
+        .cxxflag("-std=c++11")
         .define("BUILD_STATIC_LIB", "ON")
         .build();
 


### PR DESCRIPTION
I won't claim that I know why this is useful. It doesn't seem to change anything in my setup, but it also doesn't make it worse, and it's a reasonable enough flag to set (we also set it a couple lines below for bindgen's clang invocation).