### PR TITLE
Upgrade bindgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.49.0
+FROM rust:1.68.2
 RUN apt update
 RUN apt install -y cmake libclang-dev libc++-dev gcc-multilib
 WORKDIR /app

--- a/lightgbm-sys/Cargo.toml
+++ b/lightgbm-sys/Cargo.toml
@@ -13,5 +13,5 @@ exclude = ["README.md", ".gitlab-ci.yml", ".hgeol", ".gitignore", ".appveyor.yml
 libc = "0.2.81"
 
 [build-dependencies]
-bindgen = "0.56.0"
+bindgen = "0.64.0"
 cmake = "0.1"

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, c_double, c_longlong, c_void};
 use std;
+use std::convert::TryInto;
 use std::ffi::CString;
 
 use serde_json::Value;
@@ -174,7 +175,7 @@ impl Booster {
             self.handle,
             feature_name_length as i32,
             &mut num_feature_names,
-            num_feature as u64,
+            num_feature.try_into().unwrap(),
             &mut out_buffer_len,
             out_strs.as_ptr() as *mut *mut c_char
         ))?;


### PR DESCRIPTION
https://github.com/vaaaaanquish/lightgbm-rs/issues/46

Upgrade bindgen crate to surpress a warning that says nom v5.1.2, which is indirectly depended by bindgen v0.56.0, will be rejected by a future version of Rust